### PR TITLE
Not needed anymore with the official image.

### DIFF
--- a/docker-compose-tunnels.yml
+++ b/docker-compose-tunnels.yml
@@ -17,7 +17,6 @@ services:
     environment:
       - PUID=1000
       - PGID=1000
-      - TZ=Europe/London
     volumes:
         - './data/syncthing:/config'
         - './http-root/chaotic-aur:/repo'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,7 +26,6 @@ services:
     environment:
       - PUID=1000
       - PGID=1000
-      - TZ=Europe/London
     volumes:
         - './data/syncthing:/config'
         - './http-root/chaotic-aur:/repo'


### PR DESCRIPTION
The Timezone definition isn't needed anymore with the official image.
It was required with linuxserver images because they didn't pack tzdata in it.

The official image of syncthing does since [this commit](https://github.com/syncthing/syncthing/commit/438f6875919ada3f0babee2870dbaecacc7e7e15)

My mirror run without it with no issue.

Signed-off-by: Gontier Julien <gontierjulien68@gmail.com>