### PR TITLE
Improve nginx performance a little and best practice stuff.

### DIFF
--- a/preset/nginx.conf
+++ b/preset/nginx.conf
@@ -22,6 +22,12 @@ events {
 }
 
 http {
+	# By default, multi-threading is disabled, so we enable it.
+	aio threads;
+
+	# Even if it not really need, it always good practice to set it up.
+    charset utf-8;
+
 	# Includes mapping of file name extensions to MIME types of responses
 	# and defines the default type.
 	include /etc/nginx/mime.types;

--- a/preset/nginx.conf
+++ b/preset/nginx.conf
@@ -26,7 +26,7 @@ http {
 	aio threads;
 
 	# Even if it not really need, it always good practice to set it up.
-    charset utf-8;
+	charset utf-8;
 
 	# Includes mapping of file name extensions to MIME types of responses
 	# and defines the default type.


### PR DESCRIPTION
By default, multi-threading is disabled in nginx, so by enabling it we can greatly improve it performance and mirrors can deliver faster and more packages (if they have the bandwidth but it still more efficient).

The second change is just best practice when serving any type of content to clients.

As always tested and no issues to be reported on my mirror.

Signed-off-by: Gontier Julien [gontierjulien68@gmail.com](mailto:gontierjulien68@gmail.com)