### PR TITLE
Fix typo causing entrypoint interpolation error

### DIFF
--- a/docker-compose-tunnels.yml
+++ b/docker-compose-tunnels.yml
@@ -40,7 +40,7 @@ services:
             trap exit TERM;
             sleep 10;
             while :; do
-                apikey="$(grep -oPm 1 '(?<=\<apikey\>).*(?=\</apikey\>)' /data/syncthing/config.xml)"
+                apikey="$$(grep -oPm 1 '(?<=\<apikey\>).*(?=\</apikey\>)' /data/syncthing/config.xml)"
                 curl -X POST -H "X-API-Key: $$apikey" http://syncthing:8384/rest/db/revert?folder=jhcrt-m2dra;
                 sed -i -r '/<device id="ZDHVMSP-EW4TMWX-DBH2W4P-HV5A6OY-BBEFABO-QTENANJ-RJ6GKNX-6KCG7QY"/! s|(^ *<device .*id="[^"]+".*skipIntroductionRemovals="false".*introducedBy=")(">)|\1ZDHVMSP-EW4TMWX-DBH2W4P-HV5A6OY-BBEFABO-QTENANJ-RJ6GKNX-6KCG7QY\2|' /data/syncthing/config.xml
                 sleep 1h &

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,7 +49,7 @@ services:
             trap exit TERM;
             sleep 10;
             while :; do
-                apikey="$(grep -oPm 1 '(?<=\<apikey\>).*(?=\</apikey\>)' /data/syncthing/config.xml)"
+                apikey="$$(grep -oPm 1 '(?<=\<apikey\>).*(?=\</apikey\>)' /data/syncthing/config.xml)"
                 curl -X POST -H "X-API-Key: $$apikey" http://syncthing:8384/rest/db/revert?folder=jhcrt-m2dra;
                 sed -i -r '/<device id="ZDHVMSP-EW4TMWX-DBH2W4P-HV5A6OY-BBEFABO-QTENANJ-RJ6GKNX-6KCG7QY"/! s|(^ *<device .*id="[^"]+".*skipIntroductionRemovals="false".*introducedBy=")(">)|\1ZDHVMSP-EW4TMWX-DBH2W4P-HV5A6OY-BBEFABO-QTENANJ-RJ6GKNX-6KCG7QY\2|' /data/syncthing/config.xml
                 sleep 1h &


### PR DESCRIPTION
```
ERROR: Invalid interpolation format for "entrypoint" option in service "chaotic-management": "trap exit TERM;
sleep 10;
while :; do
    apikey="$(grep -oPm 1 '(?<=\<apikey\>).*(?=\</apikey\>)' /data/syncthing/config.xml)"
    curl -X POST -H "X-API-Key: $$apikey" http://syncthing:8384/rest/db/revert?folder=jhcrt-m2dra;
    sed -i -r '/<device id="ZDHVMSP-EW4TMWX-DBH2W4P-HV5A6OY-BBEFABO-QTENANJ-RJ6GKNX-6KCG7QY"/! s|(^ *<device .*id="[^"]+".*skipIntroductionRemovals="false".*introducedBy=")(">)|\1ZDHVMSP-EW4TMWX-DBH2W4P-HV5A6OY-BBEFABO-QTENANJ-RJ6GKNX-6KCG7QY\2|' /data/syncthing/config.xml
    sleep 1h &
    wait $${!};
done;
"

```