### PR TITLE
Respect docker compose specs

### DIFF
--- a/run
+++ b/run
@@ -30,9 +30,9 @@ if [ "$USE_TUNNELS" != "true" ]; then
     docker run -p 80:80 -p 443:443 --rm -v "$PWD/data/letsencrypt/etc:/etc/letsencrypt" -v "$PWD/data/letsencrypt/var:/var/lib/letsencrypt" certbot/certbot:${LETSENCRYPT_TAG:-latest} certonly --standalone --non-interactive --agree-tos --cert-name chaotic -n -m "$EMAIL" -d "$DOMAIN_NAME"
   fi
 elif [ ! -e "./data/cloudflared/home/.cloudflared/cert.pem" ]; then
-  docker-compose -f docker-compose-tunnels.yml run --rm cloudflared login
-  docker-compose -f docker-compose-tunnels.yml run --rm cloudflared --origincert /root/.cloudflared/cert.pem tunnel create $DOMAIN_NAME
-  docker-compose -f docker-compose-tunnels.yml run --rm cloudflared --origincert /root/.cloudflared/cert.pem tunnel route dns $DOMAIN_NAME $DOMAIN_NAME
+  docker compose -f docker-compose-tunnels.yml run --rm cloudflared login
+  docker compose -f docker-compose-tunnels.yml run --rm cloudflared --origincert /root/.cloudflared/cert.pem tunnel create $DOMAIN_NAME
+  docker compose -f docker-compose-tunnels.yml run --rm cloudflared --origincert /root/.cloudflared/cert.pem tunnel route dns $DOMAIN_NAME $DOMAIN_NAME
 fi
 
 if [ ! -e ./http-root/chaotic-aur ]; then
@@ -70,7 +70,7 @@ gawk -i inplace '/<folder id="jhcrt-m2dra"/ {
 1' ./data/syncthing/config.xml
 
 if [ "$USE_TUNNELS" != "true" ]; then
-  docker-compose -f docker-compose.yml up ${COMPOSEFLAGS-"-d"}
+  docker compose -f docker-compose.yml up ${COMPOSEFLAGS-"-d"}
 else
-  docker-compose -f docker-compose-tunnels.yml up ${COMPOSEFLAGS-"-d"}
+  docker compose -f docker-compose-tunnels.yml up ${COMPOSEFLAGS-"-d"}
 fi

--- a/stop
+++ b/stop
@@ -8,9 +8,9 @@ if [[ $EUID -ne 0 ]]; then
 fi
 
 if [ -e "./data/cloudflared/home/.cloudflared/cert.pem" ]; then
-    docker-compose -f docker-compose-tunnels.yml down
-    docker-compose -f docker-compose.yml down
+    docker compose -f docker-compose-tunnels.yml down
+    docker compose -f docker-compose.yml down
 else
-    docker-compose -f docker-compose.yml down
-    docker-compose -f docker-compose-tunnels.yml down
+    docker compose -f docker-compose.yml down
+    docker compose -f docker-compose-tunnels.yml down
 fi

--- a/update
+++ b/update
@@ -33,9 +33,9 @@ fi
 source .env
 
 if [ "$USE_TUNNELS" != "true" ]; then
-  docker-compose -f docker-compose.yml pull
+  docker compose -f docker-compose.yml pull
 else
-  docker-compose -f docker-compose-tunnels.yml pull
+  docker compose -f docker-compose-tunnels.yml pull
 fi
 
 ./run


### PR DESCRIPTION
Since "sometime time" it is preferred to use ["docker compose" instead of "docker-compose".
](https://docs.docker.com/get-started/08_using_compose/)This should be fine to merge unless a mirror have an old version (ex: debian docker-compose instead of the official docker repo)
[More here](https://github.com/docker/roadmap/issues/15l)


Also from the docker-compose spec the ["version" variables is DEPRECATED](https://docs.docker.com/compose/compose-file/#compose-file), but i'll would like your feekbacks on it before making a commit for it.

Signed-off-by: Gontier Julien <gontierjulien68@gmail.com>