### PR TITLE
Make container names unique

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.7"
 services:
   nginx-letsencrypt:
     image: nginx
-    container_name: nginx
+    container_name: nginx-letsencrypt
     hostname: ${DOMAIN_NAME:?err}
     volumes:
       - './http-root:/var/lib/nginx/html/http-root:ro'
@@ -23,7 +23,7 @@ services:
 
   nginx-cloudflared:
     image: nginx
-    container_name: nginx
+    container_name: nginx-cloudflared
     hostname: ${DOMAIN_NAME:?err}
     volumes:
       - './http-root:/var/lib/nginx/html/http-root:ro'


### PR DESCRIPTION
Docker gets angry if they're not unique. They should have always been unique per spec. It's now a problem with the latest release.