### PR TITLE
Drop Docker version string

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3.7"
 services:
   nginx-letsencrypt:
     image: nginx


### PR DESCRIPTION
Compose version 1 has been deprecated since June 2023, so there is no longer a need to specify version. If `version` is specified, it results in a warning.

The latest schema will always prefer the latest version: https://github.com/compose-spec/compose-spec/blob/master/spec.md#version-and-name-top-level-elements